### PR TITLE
feat: add pre-flight checks to brainstorming skill

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -210,7 +210,8 @@ After validating the design direction, evaluate whether detailed UX design is ne
 - **using-git-worktrees** — During pre-flight checks, if user is on `main`/`master` and wants a branch
 
 **Called by:**
-- Any task that needs creative design work (per skill description trigger)
+- Directly via `/brainstorming`
+- Any task creating features, building components, adding functionality, or modifying behavior (per skill trigger)
 
 **Pairs with:**
 - **writing-plans** — Terminal state; brainstorming always transitions to planning


### PR DESCRIPTION
## Summary

- Adds soft-gate pre-flight checks to the brainstorming skill enforcing CONTRIBUTING.md workflow ordering (issue → branch → brainstorm)
- New Step 1 asks for a GitHub issue number (verified via `gh issue view`) and checks the current branch, warning if on `main`/`master` with an offer to invoke `/using-git-worktrees`
- Updates the DOT process flow diagram, design doc template (with Issue/Date/Branch header), and adds an Integration section

Closes #1

<details>
<summary>Implementation plan</summary>

Single-task plan modifying `.claude/skills/brainstorming/SKILL.md`:

1. Insert "Pre-flight Checks" section with issue check (1a) and branch check (1b)
2. Renumber checklist from 1-8 to 1-9
3. Update DOT diagram with pre-flight entry nodes
4. Update terminal state note to include `using-git-worktrees`
5. Update design doc template with Issue/Date/Branch header
6. Add Integration section

Full plan: `docs/plans/2026-03-03-brainstorming-preflight-checks.md`
Design doc: `docs/plans/2026-03-03-brainstorming-preflight-checks-design.md`

</details>

## Test Plan
- [ ] Invoke `/brainstorming` on `main` — should warn about branch and offer worktree creation
- [ ] Invoke `/brainstorming` on a feature branch with no issue — should warn about missing issue
- [ ] Invoke `/brainstorming` with a valid issue number — should verify via `gh issue view` and proceed
- [ ] Verify design doc output includes Issue/Date/Branch header
- [ ] Verify existing brainstorming behavior (questions, approaches, design sections) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)