### PR TITLE
docs: add dev-container shell function for Apple Container

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -103,7 +103,7 @@ dev-container() {
   }
 
   local name_hash
-  name_hash=$(printf '%s' "$project_dir" | shasum | cut -c1-12)
+  name_hash=$(printf '%s' "$project_dir" | md5 | cut -c1-12)
   local container_name="dev-${name_hash}"
 
   if container inspect "$container_name" &>/dev/null
@@ -160,7 +160,7 @@ Then: `dev-container ~/Projects/my-app`
 ### What each step does
 
 - **Argument validation** — Requires exactly one argument (a directory path) and verifies the directory exists.
-- **Container naming** — The container is named `dev-<hash>` where `<hash>` is the first 12 characters of the SHA-1 of the project's absolute path. This avoids collisions between projects that share a basename (e.g., `~/work/app` and `~/personal/app`) and eliminates edge cases with special characters in directory names.
+- **Container naming** — The container is named `dev-<hash>` where `<hash>` is the first 12 characters of the MD5 of the project's absolute path. This avoids collisions between projects that share a basename (e.g., `~/work/app` and `~/personal/app`) and eliminates edge cases with special characters in directory names. Uses `md5` (native macOS BSD utility) rather than `shasum` (Perl wrapper).
 - **Collision check** — If a container for this project already exists, prints the `container rm` command and exits.
 - `mkdir -p "$nix_cache" "$claude_config"` — Ensure the shared Nix store and Claude config directories exist on the host.
 - `-v "$project_dir:/workspace"` — Bind-mount the project directory into the container. Edits are visible on both sides.
@@ -207,6 +207,23 @@ container ls -a --format json \
 ```
 
 The shared Nix store (`~/.dev-containers/nix/`) and Claude config (`~/.dev-containers/claude/`) persist on the host. Delete them to reclaim disk space when no containers need them.
+
+### Resuming a stopped container
+
+Containers persist after exit. To re-enter one:
+
+```bash
+container start dev-<hash>
+container exec -it dev-<hash> /bin/sh -l
+```
+
+`container start` resumes the stopped container. `container exec -it` opens an interactive login shell inside it — the `-l` flag sources `~/.profile`, which restores the PATH and `claude` alias configured during the original setup.
+
+To find the container name:
+
+```bash
+container ls -a   # shows all containers including stopped ones
+```
 
 ### Environment variables
 

--- a/docs/plans/2026-03-04-apple-container-launcher-design.md
+++ b/docs/plans/2026-03-04-apple-container-launcher-design.md
@@ -23,6 +23,18 @@ OCI-compatible). No custom image build required.
 
 ## Architecture
 
+### Container Naming
+
+Containers are named `dev-<hash>` where `<hash>` is the first 12 characters
+of the MD5 of the project's absolute path. This avoids collisions between
+projects that share a basename (e.g., `~/work/app` and `~/personal/app`)
+and eliminates edge cases with special characters in directory names.
+
+Uses `md5` (native macOS BSD utility) rather than `shasum` (Perl wrapper).
+
+The function checks for an existing container with the same name before
+launching and prints the `container rm` command if one exists.
+
 ### Bind Mounts
 
 | Host Path | Container Path | Purpose |
@@ -64,6 +76,10 @@ uses a direct path test (`[ -x /nix/.npm-global/bin/claude ]`) rather than
 `command -v` to avoid false negatives before PATH is configured. Cached in
 the shared Nix store so subsequent containers skip installation.
 
+The setup script runs with `set -e` so any uncaught failure aborts the
+container launch. The install block uses `||` chains for its own error
+handling (which suppresses `set -e` for the left-hand side).
+
 Claude Code's config directory (`~/.claude`) is bind-mounted from the host,
 so authentication and settings persist across containers. The host stores
 API keys in the macOS Keychain, but inside the Linux container Claude Code
@@ -87,6 +103,19 @@ Both the PATH export and alias are written to `~/.profile` on the container
 filesystem (`/root/.profile` — not inside a bind mount). The
 `# dev-container` marker guards against duplicate entries if a stopped
 container is restarted. The alias only exists inside the container.
+
+### Resuming a Stopped Container
+
+Containers persist after exit. To re-enter:
+
+```bash
+container start dev-<hash>
+container exec -it dev-<hash> /bin/sh -l
+```
+
+`container start` resumes the stopped container. `container exec -it` opens
+an interactive login shell. The `-l` flag sources `~/.profile`, restoring
+the PATH and `claude` alias from the original setup.
 
 ### Environment Variables
 
@@ -121,3 +150,4 @@ See `USAGE.md` — the function is defined and documented there.
 
 - macOS 26 (Tahoe) with Apple Container installed
 - Apple Silicon Mac
+- [jq](https://jqlang.github.io/jq/) (used by cleanup commands)


### PR DESCRIPTION
## Summary

- Adds a `dev-container` shell function to USAGE.md that launches projects inside Apple Containers
- Uses stock `nixos/nix` OCI image with bind-mounted project directory and shared Nix store
- Auto-installs Claude Code on first run (cached across containers via shared `/nix` mount)
- Aliases `claude` to `--dangerously-skip-permissions` inside the container (isolated environment)
- Names containers `dev-<hash>` using MD5 of the project's absolute path to avoid collisions
- Detects container name collisions before launch
- Documents cleanup commands and how to resume stopped containers

## Design

See `docs/plans/2026-03-04-apple-container-launcher-design.md`

## Test plan

- [ ] Verify `dev-container ~/some/project` launches an Apple Container on macOS 26
- [ ] Verify project files are visible at `/workspace` inside the container
- [ ] Verify shared Nix store persists across container restarts
- [ ] Verify Claude Code installs on first run and is cached on subsequent runs
- [ ] Verify `claude` alias includes `--dangerously-skip-permissions`
- [ ] Verify SSH agent forwarding works for git operations
- [ ] Verify collision is detected when a container for the same project path exists
- [ ] Verify `container stop` / `container rm` cleanup commands work as documented
- [ ] Verify `container start` + `container exec -it` resumes a stopped container with PATH and alias intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)